### PR TITLE
feat: support CJS and ESM with type declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
 .DS_Store
-src/**/*.js
+node_modules
+dist
 coverage

--- a/README.md
+++ b/README.md
@@ -32,43 +32,43 @@ yarn add @zilliqa-js/scilla-json-utils
 
 ## Usage
 
-### I. `getJSONValue(type: string, value: any)`
+### I. `scillaJSONVal(type: string, value: any)`
 
 #### Integers (`UintX` / `IntX`)
 
 ```js
-import { getJSONValue } from "@zilliqa-js/scilla-json-utils";
+import { scillaJSONVal } from "@zilliqa-js/scilla-json-utils";
 
-getJSONValue("Uint256", "1");
+scillaJSONVal("Uint256", "1");
 // Output: "1"
 ```
 
 ```js
-getJSONValue("Int256", "-1");
+scillaJSONVal("Int256", "-1");
 // Output: "-1"
 ```
 
 ```js
-getJSONValue("Uint256", 1);
+scillaJSONVal("Uint256", 1);
 // Output: "1"
 ```
 
 ```js
-getJSONValue("Int256", -1);
+scillaJSONVal("Int256", -1);
 // Output: "-1"
 ```
 
 #### Strings (`String`)
 
 ```js
-getJSONValue("String", "Foo");
+scillaJSONVal("String", "Foo");
 // Output: "Foo"
 ```
 
 #### Byte Strings (`ByStrX`)
 
 ```js
-getJSONValue("ByStr20", "0x85E0bef5F9a11821f9B2BA778a05963436B5e720");
+scillaJSONVal("ByStr20", "0x85E0bef5F9a11821f9B2BA778a05963436B5e720");
 // Output: "0x85e0bef5f9a11821f9b2ba778a05963436b5e720"
 // Note that the output is lowercased.
 ```
@@ -76,19 +76,19 @@ getJSONValue("ByStr20", "0x85E0bef5F9a11821f9B2BA778a05963436B5e720");
 #### Block Numbers (`BNum`)
 
 ```js
-getJSONValue("BNum", "1");
+scillaJSONVal("BNum", "1");
 // Output: "1"
 ```
 
 ```js
-getJSONValue("BNum", 1);
+scillaJSONVal("BNum", 1);
 // Output: "1"
 ```
 
 #### Boolean (`Bool`)
 
 ```js
-getJSONValue("Bool", false);
+scillaJSONVal("Bool", false);
 ```
 
 Output:
@@ -106,7 +106,7 @@ Output:
 ##### None
 
 ```js
-getJSONValue("Option (ByStr20)", undefined);
+scillaJSONVal("Option (ByStr20)", undefined);
 ```
 
 Output:
@@ -122,7 +122,7 @@ Output:
 ##### Some
 
 ```js
-getJSONValue("Option (ByStr20)", "0x0000000000000000000000000000000000000000");
+scillaJSONVal("Option (ByStr20)", "0x0000000000000000000000000000000000000000");
 ```
 
 Output:
@@ -138,7 +138,7 @@ Output:
 #### Pair (`Pair`)
 
 ```js
-getJSONValue("Pair (ByStr20) (Uint256)", [
+scillaJSONVal("Pair (ByStr20) (Uint256)", [
   "0x0000000000000000000000000000000000000000",
   1,
 ]);
@@ -157,7 +157,7 @@ Output:
 #### List (`List`)
 
 ```js
-getJSONValue("List (Pair (ByStr20) (Uint256))", [
+scillaJSONVal("List (Pair (ByStr20) (Uint256))", [
   ["0x85E0bef5F9a11821f9B2BA778a05963436B5e720", 1],
   ["0x85E0bef5F9a11821f9B2BA778a05963436B5e720", 2],
 ]);
@@ -189,7 +189,7 @@ type Foo =
 ```
 
 ```js
-getJSONValue(
+scillaJSONVal(
   "0x85E0bef5F9a11821f9B2BA778a05963436B5e720.Foo.Bar.of.ByStr20.BNum",
   ["0x0000000000000000000000000000000000000000", 1]
 );
@@ -205,7 +205,7 @@ Output:
 }
 ```
 
-### II. `getJSONParams({[vname: string]: [type: string, value: any]})`
+### II. `scillaJSONParams({[vname: string]: [type: string, value: any]})`
 
 ```ocaml
 type Foo =
@@ -214,9 +214,9 @@ type Foo =
 ```
 
 ```js
-import { getJSONParams } from "@zilliqa-js/scilla-json-utils";
+import { scillaJSONParams } from "@zilliqa-js/scilla-json-utils";
 
-getJSONParams({
+scillaJSONParams({
   x: [
     "0x85E0bef5F9a11821f9B2BA778a05963436B5e720.Foo.Bar.of.ByStr20.BNum",
     ["0x0000000000000000000000000000000000000000", 1],

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@zilliqa-js/scilla-json-utils",
   "version": "0.1.0",
   "scripts": {
-    "build": "tsc",
-    "test": "jest --collect-coverage",
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.json",
+    "test": "npm run build && jest --collect-coverage",
     "release": "npm test && npm run build && npm publish --access=public"
   },
   "devDependencies": {
@@ -13,12 +13,15 @@
     "ts-jest": "^27.1.1",
     "typescript": "^4.5.2"
   },
-  "type": "module",
-  "main": "src/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "node_modules",
     "package.json",
-    "src/index.js",
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/cjs/index.js",
     "LICENSE",
     "README.md"
   ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { scillaJSONVal, scillaJSONParams, extractTypes } from ".";
+import { scillaJSONVal, scillaJSONParams, extractTypes } from "./index";
 
 describe("scillaJSONVal", () => {
   const testCases = [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { getJSONValue, getJSONParams, extractTypes } from ".";
+import { scillaJSONVal, scillaJSONParams, extractTypes } from ".";
 
-describe("getJSONValue", () => {
+describe("scillaJSONVal", () => {
   const testCases = [
     {
       type: "0x85E0bef5F9a11821f9B2BA778a05963436B5e720.Foo.Bar",
@@ -180,13 +180,13 @@ describe("getJSONValue", () => {
   for (const testCase of testCases) {
     const { value, type, want } = testCase;
     it(type, () => {
-      const res = getJSONValue(value, type);
+      const res = scillaJSONVal(type, value);
       expect(JSON.stringify(res)).toBe(JSON.stringify(want));
     });
   }
 });
 
-describe("getJSONParams", () => {
+describe("scillaJSONParams", () => {
   const testCases = [
     // 0xf59c79db958bafdf9d81df29d50edcc14911d40c.Foo.Bar.of.ByStr20.BNum
     {
@@ -312,7 +312,7 @@ describe("getJSONParams", () => {
   for (const testCase of testCases) {
     const { param, want } = testCase;
     it(JSON.stringify(param), () => {
-      const res = getJSONParams(param);
+      const res = scillaJSONParams(param);
       expect(JSON.stringify(res)).toBe(JSON.stringify(want));
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export const extractTypes = (type: string) => {
   return result;
 };
 
-export const getJSONValue = (value: any, type?: string): any => {
+export const scillaJSONVal = (type: string, value: any): any => {
   // User-defined ADT
   if (typeof type === "string" && type.startsWith("0x")) {
     const arr = type.split(".");
@@ -52,7 +52,7 @@ export const getJSONValue = (value: any, type?: string): any => {
     let values = [] as any[];
     if (structIndex !== -1) {
       const structTypes = arr.slice(structIndex + 1);
-      values = structTypes.map((t, i) => getJSONValue(value[i], t));
+      values = structTypes.map((t, i) => scillaJSONVal(t, value[i]));
     }
     return {
       argtypes: [],
@@ -97,7 +97,7 @@ export const getJSONValue = (value: any, type?: string): any => {
     const types = extractTypes(type);
     return {
       argtypes: types,
-      arguments: value === undefined ? [] : [getJSONValue(value, types[0])],
+      arguments: value === undefined ? [] : [scillaJSONVal(types[0], value)],
       constructor: value === undefined ? "None" : "Some",
     };
   }
@@ -107,7 +107,7 @@ export const getJSONValue = (value: any, type?: string): any => {
     type.startsWith("List") &&
     Array.isArray(value)
   ) {
-    return value.map((x) => getJSONValue(x, extractTypes(type)[0]));
+    return value.map((x) => scillaJSONVal(extractTypes(type)[0], x));
   }
 
   if (
@@ -118,7 +118,7 @@ export const getJSONValue = (value: any, type?: string): any => {
     const types = extractTypes(type);
     return {
       argtypes: types,
-      arguments: value.map((x, i) => getJSONValue(x, types[i])),
+      arguments: value.map((x, i) => scillaJSONVal(types[i], x)),
       constructor: "Pair",
     };
   }
@@ -126,7 +126,7 @@ export const getJSONValue = (value: any, type?: string): any => {
   return value;
 };
 
-export const getJSONParams = (obj: { [x: string]: any }) => {
+export const scillaJSONParams = (obj: { [x: string]: any }) => {
   const result = Object.keys(obj).map((vname) => {
     const [type, value] = obj[vname];
 
@@ -136,14 +136,14 @@ export const getJSONParams = (obj: { [x: string]: any }) => {
       const typeName = arr[1];
       return {
         type: `${contractAddress}.${typeName}`,
-        value: getJSONValue(value, type),
+        value: scillaJSONVal(type, value),
         vname,
       };
     }
 
     return {
       type,
-      value: getJSONValue(value, type),
+      value: scillaJSONVal(type, value),
       vname,
     };
   });

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": false,
+    "outDir": "./dist/cjs"
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "include": [
+    "./src"
+  ],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
@@ -11,7 +15,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2015",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -24,7 +28,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ES2022",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -42,12 +46,12 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
This PR supports CJS and ESM with declaration file to close #1. 

It also change functions names and types as the following
- `getJSONValue: (value: any, type?: string | undefined)` -> `scillaJSONVal: (type: string, value: any)`
- `getJSONParams: (obj: { [x: string]: any })` -> `scillaJSONParams: (obj: { [x: string]: any })`

